### PR TITLE
epics-base, autosave, seq: remove :provided_by_macros

### DIFF
--- a/Formula/autosave.rb
+++ b/Formula/autosave.rb
@@ -4,6 +4,8 @@ class Autosave < Formula
   url "https://github.com/epics-modules/autosave/archive/R5-10.tar.gz"
   version "5.10"
   sha256 "3f4f27283b34c5798cc9ab27d38c7191e963b0bac82cb1680a6dccddac57f48c"
+  # Revision 1: Removed :provided_by_macros arg to keg_only
+  revision 1
 
   bottle do
     root_url "https://github.com/ulrikpedersen/homebrew-mytap/releases/download/autosave-5.10"
@@ -11,8 +13,7 @@ class Autosave < Formula
     sha256 "158f35e55792d2b92497c7acea491c8f0f55afc8e92fcabfe256fdd4aef25fba" => :x86_64_linux
   end
 
-  keg_only :provided_by_macos,
-    "the EPICS build system does not lend itself particularly well to installing in a central system location"
+  keg_only "the EPICS build system does not lend itself particularly well to installing in a central system location"
 
   depends_on "epics-base"
 

--- a/Formula/epics-base.rb
+++ b/Formula/epics-base.rb
@@ -6,7 +6,8 @@ class EpicsBase < Formula
   sha256 "1de65638a806be6c0eebc0b7840ed9dd1a1a7879bcb6ab0da88a1e8e456b709c"
   # Revisions:
   # 1: fixed issue with installing executables directly into opt_bin
-  revision 1
+  # 2: Removed :provided_by_macros arg to keg_only
+  revision 2
 
   bottle do
     root_url "https://github.com/ulrikpedersen/homebrew-mytap/releases/download/epics-base-7.0.3.1_1"
@@ -14,8 +15,7 @@ class EpicsBase < Formula
     sha256 "15aaa88dddcbceedd530a5181cafb4a4eaff4fd4703ef1f8894e31083aab89e0" => :x86_64_linux
   end
 
-  keg_only :provided_by_macos,
-    "the EPICS build system does not lend itself particularly well to installing in a central system location"
+  keg_only "the EPICS build system does not lend itself particularly well to installing in a central system location"
 
   depends_on "re2c"
 

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -4,6 +4,8 @@ class Seq < Formula
   url "https://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-2.2.8.tar.gz"
   # version "2.2.8"
   sha256 "f19e982d46ed467ba8604de346cac838ea27eef39462fe6ae429dc49f338a794"
+  # Revision 1: Removed :provided_by_macros arg to keg_only
+  revision 1
 
   bottle do
     root_url "https://github.com/ulrikpedersen/homebrew-mytap/releases/download/seq-2.2.8"
@@ -11,8 +13,7 @@ class Seq < Formula
     sha256 "f3212176f36d28da5b746c32a6d15f9ca2bc069e06c0e0165501ba5d94b9f87b" => :x86_64_linux
   end
 
-  keg_only :provided_by_macos,
-    "the EPICS build system does not lend itself particularly well to installing in a central system location"
+  keg_only "the EPICS build system does not lend itself particularly well to installing in a central system location"
 
   depends_on "epics-base"
   depends_on "re2c"


### PR DESCRIPTION
This is becase 'brew style' errors on "Formulae that are keg_only :provided_by_macos should be added to the PROVIDED_BY_MACOS_FORMULAE list (in the Homebrew/brew repo)".